### PR TITLE
Support for other projections

### DIFF
--- a/2.0.0/README.md
+++ b/2.0.0/README.md
@@ -98,12 +98,43 @@ as invalid and refuse operation.
     // An integer specifying the maximum zoom level. MUST be >= minzoom.
     "maxzoom": 11,
 
+    // OPTIONAL. Default: "EPSG:3785"
+    // CRS Name.
+    "crs": "EPSG:25833",
+
+    // OPTIONAL. Default: "+proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +a=6378137 +b=6378137 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs"
+    // A Proj4 definition for the projection used. Defaults to global-mercator
+    // (aka Spherical Mercator).
+    "projection": "+proj=utm +zone=33 +ellps=GRS80 +units=m +no_defs",
+
+    // OPTIONAL. Default: [0.5 / Math.PI, 0.5, -0.5 / Math.PI, 0.5]
+    // A transformation matrix [a, b, c, d] to calculate tile coordinate 
+    // from projected coordinates at a given scale, such that:
+    // tile_column = scale * (a * projected_x + b)
+    // tile_row = scale * (c * projected_y + d)
+    "transform": [1, 2500000, -1, 9045984],
+
     // OPTIONAL. Default: [-180, -90, 180, 90].
     // The maximum extent of available map tiles. Bounds MUST define an area
     // covered by all zoom levels. The bounds are represented in WGS:84
     // latitude and longitude values, in the order left, bottom, right, top.
     // Values may be integers or floating point numbers.
     "bounds": [ -180, -85.05112877980659, 180, 85.0511287798066 ],
+
+    // OPTIONAL. Default: null
+    // The maximum extent of available map tiles. Bounds MUST define an area
+    // covered by all zoom levels. The bounds are represented in the projected
+    // CRS. If specified, this overrides the bounds set by the "bounds" property.
+    // For many projections, specifying the bounds in WGS:84 does not make
+    // sense, and in that case, projected_bounds can be used instead.
+    "projected_bounds": [2500000, 0, 5000000, 9045984],
+
+    // OPTIONAL. Default: [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 
+    // 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 
+    // 33554432, 67108864, 134217728, 268435456, 536870912, 1073741824]
+    // The scale values for the defined zoom levels 0 <= z <= maxzoom.
+    "scales": [0.0001220703125, 0.000244140625, 0.00048828125, 0.0009765625, 
+    0.001953125, 0.00390625, 0.0078125, 0.015625, 0.03125, 0.0625, 0.125, 0.25, 0.5, 1.0, 2.0],
 
     // OPTIONAL. Default: null.
     // The first value is the longitude, the second is latitude (both in

--- a/2.0.0/schema.json
+++ b/2.0.0/schema.json
@@ -52,7 +52,31 @@
             "maximum": 22,
             "type": "integer"
         },
+        "crs": {
+            "type": "string"
+        },
+        "projection": {
+            "type": "string"
+        },
+        "transform": {
+            "type": "array",
+            "items": {
+                "type": "number"
+            }
+        },
         "bounds": {
+            "type": "array",
+            "items": {
+                "type": "number"
+            }
+        },
+        "projected_bounds": {
+            "type": "array",
+            "items": {
+                "type": "number"
+            }
+        },
+        "scales": {
             "type": "array",
             "items": {
                 "type": "number"


### PR DESCRIPTION
This pull request adds support for other projections than EPSG:900913 to TileJSON.

Support is added by a number of optional properties. If these properties are left out, they default to values that give EPSG:900913, so these changes are backwards compatible.

As a proof of concept, I have also written Leaflet support for this version of TileJSON: https://github.com/perliedman/leaflet-tilejson

An online example is also shown here: http://karta.kartena.se/ - the default map layer is configured using this version of TileJSON, with maps using the EPSG:2400 projection (Swedish local projection RT90).

I have intentionally not changed the version of the spec, as I see this more as a proof of concept currently, and would very much like to hear your input on extending the spec to include support for other projections, if this is something you'd like to consider at all.