### PR TITLE
Fix OpenStreetMap URLs in examples

### DIFF
--- a/1.0.0/example/osm.layer
+++ b/1.0.0/example/osm.layer
@@ -6,9 +6,9 @@
     "attribution": "(c) OpenStreetMap contributors, CC-BY-SA",
     "scheme": "xyz",
     "tiles": [
-        "http://a.tile.openstreetmap.org/${z}/${x}/${y}.png",
-        "http://b.tile.openstreetmap.org/${z}/${x}/${y}.png",
-        "http://c.tile.openstreetmap.org/${z}/${x}/${y}.png"
+        "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
     ],
     "minzoom": 0,
     "maxzoom": 18,

--- a/2.0.0/example/osm.layer
+++ b/2.0.0/example/osm.layer
@@ -6,9 +6,9 @@
     "attribution": "(c) OpenStreetMap contributors, CC-BY-SA",
     "scheme": "xyz",
     "tiles": [
-        "http://a.tile.openstreetmap.org/${z}/${x}/${y}.png",
-        "http://b.tile.openstreetmap.org/${z}/${x}/${y}.png",
-        "http://c.tile.openstreetmap.org/${z}/${x}/${y}.png"
+        "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
     ],
     "minzoom": 0,
     "maxzoom": 18,

--- a/2.0.1/example/osm.layer
+++ b/2.0.1/example/osm.layer
@@ -6,9 +6,9 @@
     "attribution": "(c) OpenStreetMap contributors, CC-BY-SA",
     "scheme": "xyz",
     "tiles": [
-        "http://a.tile.openstreetmap.org/${z}/${x}/${y}.png",
-        "http://b.tile.openstreetmap.org/${z}/${x}/${y}.png",
-        "http://c.tile.openstreetmap.org/${z}/${x}/${y}.png"
+        "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
     ],
     "minzoom": 0,
     "maxzoom": 18,

--- a/2.1.0/example/osm.layer
+++ b/2.1.0/example/osm.layer
@@ -6,9 +6,9 @@
     "attribution": "(c) OpenStreetMap contributors, CC-BY-SA",
     "scheme": "xyz",
     "tiles": [
-        "http://a.tile.openstreetmap.org/${z}/${x}/${y}.png",
-        "http://b.tile.openstreetmap.org/${z}/${x}/${y}.png",
-        "http://c.tile.openstreetmap.org/${z}/${x}/${y}.png"
+        "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
     ],
     "minzoom": 0,
     "maxzoom": 18,

--- a/2.2.0/example/osm.layer
+++ b/2.2.0/example/osm.layer
@@ -6,9 +6,9 @@
     "attribution": "(c) OpenStreetMap contributors, CC-BY-SA",
     "scheme": "xyz",
     "tiles": [
-        "http://a.tile.openstreetmap.org/${z}/${x}/${y}.png",
-        "http://b.tile.openstreetmap.org/${z}/${x}/${y}.png",
-        "http://c.tile.openstreetmap.org/${z}/${x}/${y}.png"
+        "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
     ],
     "minzoom": 0,
     "maxzoom": 18,


### PR DESCRIPTION
- Use https everywhere
- replace `${z}/${x}/${y}` by `{z}/{x}/{y}`

In the OSM wiki,the tile server URLs are specified as:

   https://a.tile.openstreetmap.org/${z}/${x}/${y}.png
   https://b.tile.openstreetmap.org/${z}/${x}/${y}.png
   https://c.tile.openstreetmap.org/${z}/${x}/${y}.png

See https://wiki.openstreetmap.org/wiki/Tile_servers

However, the `${x}` notation was never part of the TileJSON specification which consistently uses `{x}`.

Fixes #18