### PR TITLE
bounds

### DIFF
--- a/3.0/README.md
+++ b/3.0/README.md
@@ -46,6 +46,17 @@ REQUIRED|OPTIONAL (description of dependents/dependencies)
 **Example:**
 
 ## 3.2 `bounds`
+
+OPTIONAL. Default: [-180, -90, 180, 90].
+
+The maximum extent of available map tiles. Bounds MUST define an area covered by all zoom levels. The bounds are represented in WGS:84 latitude and longitude values, in the order left, bottom, right, top. Values may be integers or floating point numbers. The minimum/maximum values for longitude and latitude are -180/180 and -90/90 respectively. Bounds MUST NOT "wrap" around the ante-meridian. If bounds are not present, the default value assumes the set of tiles is globally distributed.
+
+```JSON
+{
+  "bounds": [ -180, -85.05112877980659, 180, 85.0511287798066 ]
+}
+```
+
 ## 3.3 `center`
 ## 3.4 `data`
 ## 3.5 `description`

--- a/3.0/README.md
+++ b/3.0/README.md
@@ -49,7 +49,7 @@ REQUIRED|OPTIONAL (description of dependents/dependencies)
 
 OPTIONAL. Default: [-180, -90, 180, 90].
 
-The maximum extent of available map tiles. Bounds MUST define an area covered by all zoom levels. The bounds are represented in WGS:84 latitude and longitude values, in the order left, bottom, right, top. Values may be integers or floating point numbers. The minimum/maximum values for longitude and latitude are -180/180 and -90/90 respectively. Bounds MUST NOT "wrap" around the ante-meridian. If bounds are not present, the default value assumes the set of tiles is globally distributed.
+The maximum extent of available map tiles. Bounds MUST define an area covered by all zoom levels. The bounds are represented in WGS:84 latitude and longitude values, in the order left, bottom, right, top. Values may be integers or floating point numbers. The minimum/maximum values for longitude and latitude are -180/180 and -90/90 respectively. Bounds MUST NOT "wrap" around the ante-meridian. If bounds are not present, the default value MAY assume the set of tiles is globally distributed.
 
 ```JSON
 {


### PR DESCRIPTION
This adds the `bounds` field to the Structure section, and includes some added text (in bold) from the current description:

> The maximum extent of available map tiles. Bounds MUST define an area covered by all zoom levels. The bounds are represented in WGS:84 latitude and longitude values, in the order left, bottom, right, top. Values may be integers or floating point numbers. **The minimum/maximum values for longitude and latitude are -180/180 and -90/90 respectively. Bounds MUST NOT "wrap" around the ante-meridian. If bounds are not present, the default value assumes the set of tiles is globally distributed.**

The new addition covers questions from https://github.com/mapbox/tilejson-spec/issues/25 and https://github.com/mapbox/tilejson-spec/issues/23 at least for the v3 perspective, but they could be redefined in v4

cc @GretaCB 