### PR TITLE
tiles

### DIFF
--- a/3.0/README.md
+++ b/3.0/README.md
@@ -37,8 +37,6 @@ TileJSON manifest files use the JSON format as described in [RFC 4627](https://w
 
 Implementations MUST treat unknown keys as if they weren't present. However, implementations MUST expose unknown key/values in their API so that API users can optionally handle these keys. Implementations MUST treat invalid values for keys as if they weren’t present. If the the field is an optional field and the value is invalid, the default value MAY be applied. If the key is required, implementations MUST treat the entire TileJSON manifest file as invalid and refuse operation.
 
-Default`
-
 ## 3.1 `attribution`
 
 OPTIONAL. Default: null.

--- a/3.0/README.md
+++ b/3.0/README.md
@@ -138,7 +138,7 @@ Include anything about _types_ of tiles? (png, mvt, webp...?)
 
 ```JSON
 {
-  tiles": [
+  "tiles": [
     "http://localhost:8888/admin/1.0.0/world-light,broadband/{z}/{x}/{y}.png"
   ]
 }

--- a/3.0/README.md
+++ b/3.0/README.md
@@ -35,7 +35,9 @@ TileJSON manifest files use the JSON format as described in [RFC 4627](https://w
 
 # 3. Structure
 
-Implementations MUST treat unknown keys as if they weren't present. However, implementations MUST expose unknown key/values in their API so that API users can optionally handle these keys. Implementations MUST treat invalid values for keys as if they weren't present. If the key is required, implementations MUST treat the entire TileJSON manifest file as invalid and refuse operation.
+Implementations MUST treat unknown keys as if they weren't present. However, implementations MUST expose unknown key/values in their API so that API users can optionally handle these keys. Implementations MUST treat invalid values for keys as if they weren’t present. If the the field is an optional field and the value is invalid, the default value MAY be applied. If the key is required, implementations MUST treat the entire TileJSON manifest file as invalid and refuse operation.
+
+Default`
 
 ## 3.1 `attribution`
 
@@ -83,7 +85,7 @@ An integer specifying the maximum zoom level. MUST be >= minzoom.
 
 OPTIONAL. Default: 0. >= 0, <= 30.
 
-An integer specifying the minimum zoom level.
+An integer specifying the minimum zoom level. MUST be <= maxzoom
 
 ```JSON
 {

--- a/3.0/README.md
+++ b/3.0/README.md
@@ -134,8 +134,6 @@ REQUIRED.
 
 An array of tile endpoints. {z}, {x} and {y}, if present, are replaced with the corresponding integers. If multiple endpoints are specified, clients may use any combination of endpoints. All endpoints MUST return the same content for the same URL. The array MUST contain at least one endpoint.
 
-Include anything about _types_ of tiles? (png, mvt, webp...?)
-
 ```JSON
 {
   "tiles": [

--- a/3.0/README.md
+++ b/3.0/README.md
@@ -66,8 +66,30 @@ A text description of the tileset. The description can contain any legal charact
 
 ## 3.6 `grids`
 ## 3.7 `legend`
+
 ## 3.8 `maxzoom`
+
+OPTIONAL. Default: 30. >= 0, <= 30.
+
+An integer specifying the maximum zoom level. MUST be >= minzoom.
+
+```JSON
+{
+  "maxzoom": "11"
+}
+```
+
 ## 3.9 `minzoom`
+
+OPTIONAL. Default: 0. >= 0, <= 30.
+
+An integer specifying the minimum zoom level.
+
+```JSON
+{
+  "minzoom": "0"
+}
+```
 
 ## 3.10 `name`
 
@@ -82,6 +104,17 @@ A name describing the tileset. The name can contain any legal character. Impleme
 ```
 
 ## 3.11 `scheme`
+
+OPTIONAL. Default: "xyz". 
+
+Either "xyz" or "tms". Influences the y direction of the tile coordinates. The global-mercator (aka Spherical Mercator) profile is assumed.
+
+```JSON
+{
+  "scheme": "xyz"
+}
+```
+
 ## 3.12 `template`
 ## 3.13 `tilejson`
 

--- a/3.0/README.md
+++ b/3.0/README.md
@@ -129,6 +129,21 @@ A semver.org style version number. Describes the version of the TileJSON spec th
 ```
 
 ## 3.14 `tiles`
+
+REQUIRED. 
+
+An array of tile endpoints. {z}, {x} and {y}, if present, are replaced with the corresponding integers. If multiple endpoints are specified, clients may use any combination of endpoints. All endpoints MUST return the same content for the same URL. The array MUST contain at least one endpoint.
+
+Include anything about _types_ of tiles? (png, mvt, webp...?)
+
+```JSON
+{
+  tiles": [
+    "http://localhost:8888/admin/1.0.0/world-light,broadband/{z}/{x}/{y}.png"
+  ]
+}
+```
+
 ## 3.15 `vector_layers`
 ## 3.16 `version`
 

--- a/3.0/README.md
+++ b/3.0/README.md
@@ -133,6 +133,7 @@ A semver.org style version number. Describes the version of the TileJSON spec th
 REQUIRED. 
 
 An array of tile endpoints. {z}, {x} and {y}, if present, are replaced with the corresponding integers. If multiple endpoints are specified, clients may use any combination of endpoints. All endpoints MUST return the same content for the same URL. The array MUST contain at least one endpoint.
+The tile extension is NOT limited to any particular format. Some of the more popular are: mvt, vector.pbf, png, webp, and jpg.
 
 ```JSON
 {

--- a/3.0/README.md
+++ b/3.0/README.md
@@ -132,8 +132,7 @@ A semver.org style version number. Describes the version of the TileJSON spec th
 
 REQUIRED. 
 
-An array of tile endpoints. {z}, {x} and {y}, if present, are replaced with the corresponding integers. If multiple endpoints are specified, clients may use any combination of endpoints. All endpoints MUST return the same content for the same URL. The array MUST contain at least one endpoint.
-The tile extension is NOT limited to any particular format. Some of the more popular are: mvt, vector.pbf, png, webp, and jpg.
+An array of tile endpoints. {z}, {x} and {y}, if present, are replaced with the corresponding integers. If multiple endpoints are specified, clients may use any combination of endpoints. All endpoints MUST return the same content for the same URL. The array MUST contain at least one endpoint. The tile extension is NOT limited to any particular format. Some of the more popular are: mvt, vector.pbf, png, webp, and jpg.
 
 ```JSON
 {

--- a/3.0/README.md
+++ b/3.0/README.md
@@ -138,7 +138,7 @@ The tile extension is NOT limited to any particular format. Some of the more pop
 ```JSON
 {
   "tiles": [
-    "http://localhost:8888/admin/1.0.0/world-light,broadband/{z}/{x}/{y}.png"
+    "http://localhost:8888/admin/1.0.0/world-light,broadband/{z}/{x}/{y}.mvt"
   ]
 }
 ```


### PR DESCRIPTION
Per https://github.com/mapbox/tilejson-spec/pull/36, this adds the `tiles` field to `Structure` section.

> REQUIRED. 
>
> An array of tile endpoints. {z}, {x} and {y}, if present, are replaced with the corresponding integers. If multiple endpoints are specified, clients may use any combination of endpoints. All endpoints MUST return the same content for the same URL. The array MUST contain at least one endpoint.

- [x] Include clarification and examples of _types_ of tiles (png, mvt, webp) per https://github.com/mapbox/tilejson-spec/issues/17
- [x] ~Include example with _and_ without zxy~ Not sure what a non-zxy tile example would be. We can add as an example later if we come across one.

cc @mapsam 