### PR TITLE
HTTPS link to creativecommons.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ TileJSON is an open standard for representing map metadata.
 # License
 
 The text of this specification is licensed under a
-[Creative Commons Attribution 3.0 United States License](http://creativecommons.org/licenses/by/3.0/us/).
+[Creative Commons Attribution 3.0 United States License](https://creativecommons.org/licenses/by/3.0/us/).
 However, the use of this spec in products and code is entirely free:
 there are no royalties, restrictions, or requirements.
 


### PR DESCRIPTION
safer and prevents a HTTP redirect