### PR TITLE
typo: corrected 'describing' and 'implementation'

### DIFF
--- a/3.0.0/README.md
+++ b/3.0.0/README.md
@@ -71,9 +71,9 @@ An array of tile endpoints. {z}, {x} and {y}, if present, are replaced with the 
 
 REQUIRED. Array<Object>.
 
-An array of objects. Each object describes one layer of vector tile data. A `vector_layer` object MUST contain the `id` and `fields` keys, and MAY contain the `description`, `minzoom`, or `maxzoom` keys. An implemenntation MAY include arbitrary keys in the object outside of those defined in this specification.
+An array of objects. Each object describes one layer of vector tile data. A `vector_layer` object MUST contain the `id` and `fields` keys, and MAY contain the `description`, `minzoom`, or `maxzoom` keys. An implementation MAY include arbitrary keys in the object outside of those defined in this specification.
 
-Note: When describinng a set of raster tiles or other tile format that does not have a "layers" concept (i.e. `"format": "jpeg"`), the `vector_layers` key is not required.
+Note: When describing a set of raster tiles or other tile format that does not have a "layers" concept (i.e. `"format": "jpeg"`), the `vector_layers` key is not required.
 
 #### 3.3.1 `id`
 


### PR DESCRIPTION
Just corrected 2 typoes (`describing` and `implementation`)